### PR TITLE
Verify the filter can be serialized and restored

### DIFF
--- a/tests/BloomFilterTest.php
+++ b/tests/BloomFilterTest.php
@@ -47,4 +47,20 @@ class BloomFilterTest extends TestCase
 
         $this->assertTrue($this->filter->exists('foo'));
     }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function serialize() : void
+    {
+        $this->filter->insert('example');
+
+        $copy = unserialize(serialize($this->filter));
+
+        $this->assertEquals($this->filter, $copy);
+
+        $this->assertTrue($copy->exists('example'));
+        $this->assertFalse($copy->exists('example2'));
+    }
 }


### PR DESCRIPTION
Most PHP apps aren't long running, so it could make sense to store the filter in cache, and restore it as needed to check against this or that.